### PR TITLE
feat(request): remove encompass and version slug from generic request…

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,10 +246,11 @@ await encompass.milestones.update(updateProcessingOptions);
 ```
 
 ### The Request Method
-If an API is not available through an explicit method in this class, the `request()` method will act as a fetch wrapper around any Encompass API call you want to make and return the response. It takes in the same arguments as any [fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) API, with the exception that the first argument is appended as a path to the Encompass API domain.
+If an API is not available through an explicit method in this class, the `request()` method will act as a fetch wrapper around any Encompass API call you want to make and return the response. It takes in the same arguments as any [fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) API, with the exception that the first argument is appended as a path to the Encompass API domain, currently `https://api.elliemae.com/`.
+
 ```typescript
 // hitting the Get Custom Fields API:
-const customFieldsResponse: Response = await encompass.request('/settings/loan/customFields');
+const customFieldsResponse: Response = await encompass.request('/encompass/v1/settings/loan/customFields');
 const data = await customFieldsResponse.json();
 console.log(data);
 
@@ -262,7 +263,7 @@ const options: RequestInit = {
   },
 };
 
-await encompass.request('/businessContacts/<some-contact-id>', options);
+await encompass.request('/encompass/v1/businessContacts/<some-contact-id>', options);
 ```
 
 Checkout the [documentation site](https://heythisispaul.github.io/EncompassConnect/classes/encompassconnectclass.encompassconnect.html) for all available methods and other examples.

--- a/__tests__/__snapshots__/encompassConnect.spec.ts.snap
+++ b/__tests__/__snapshots__/encompassConnect.spec.ts.snap
@@ -65,7 +65,7 @@ Array [
 
 exports[`EncompassConnect request fetches with the correct information 1`] = `
 Array [
-  "https://api.elliemae.com/encompass/v1test/url",
+  "https://api.elliemae.comtest/url",
   Object {
     "body": "{\\"some\\":\\"value\\"}",
     "headers": Object {

--- a/__tests__/services/__snapshots__/users.spec.ts.snap
+++ b/__tests__/services/__snapshots__/users.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`UserService getList appends the filter object as a query string 1`] = `
 Array [
-  "https://api.elliemae.com/encompass/v1/company/users?",
+  "https://api.elliemae.com/encompass/v1/company/users?groupId=1&limit=50&userName=Mr.+Peanutbutter",
   Object {
     "headers": Object {
       "Authorization": "Bearer <MOCK TOKEN VALUE>",
@@ -11,9 +11,9 @@ Array [
 ]
 `;
 
-exports[`UserService getList appends the filter object as a query string 2`] = `
+exports[`UserService getList makes the request to the correct URL 1`] = `
 Array [
-  "https://api.elliemae.com/encompass/v1/company/users?groupId=1&limit=50&userName=Mr.+Peanutbutter",
+  "https://api.elliemae.com/encompass/v1/company/users?",
   Object {
     "headers": Object {
       "Authorization": "Bearer <MOCK TOKEN VALUE>",
@@ -24,7 +24,7 @@ Array [
 
 exports[`UserService getProfile makes the API call with "me" in the url if no argument is provided 1`] = `
 Array [
-  "https://api.elliemae.com/encompass/v1/company/users/<TEST_LOS_ID>",
+  "https://api.elliemae.com/encompass/v1/company/users/me",
   Object {
     "headers": Object {
       "Authorization": "Bearer <MOCK TOKEN VALUE>",
@@ -33,9 +33,9 @@ Array [
 ]
 `;
 
-exports[`UserService getProfile makes the API call with "me" in the url if no argument is provided 2`] = `
+exports[`UserService getProfile makes the API call with provided LOS Id in the url 1`] = `
 Array [
-  "https://api.elliemae.com/encompass/v1/company/users/me",
+  "https://api.elliemae.com/encompass/v1/company/users/<TEST_LOS_ID>",
   Object {
     "headers": Object {
       "Authorization": "Bearer <MOCK TOKEN VALUE>",

--- a/src/encompassConnect.ts
+++ b/src/encompassConnect.ts
@@ -130,7 +130,12 @@ class EncompassConnect {
     options: RequestInit = {},
     customOptions: InternalRequestOptions = {},
   ): Promise<any> {
-    const { isRetry, isNotJson, version } = customOptions;
+    const {
+      isRetry,
+      isNotJson,
+      version,
+      useTruncatedBase,
+    } = customOptions;
     const shouldRetry = !isRetry && this.username && this.#password;
     const failedAuthError = new Error(
       `Token invalid. ${!isRetry && shouldRetry ? 'Will reattempt with new token' : 'Unable to get updated one.'}`,
@@ -139,7 +144,10 @@ class EncompassConnect {
       if (!this.#token) {
         await this.getToken();
       }
-      const url = `${this.base}/v${version || this.version}${path}`;
+      const url = useTruncatedBase
+        ? `${this.authBase}${path}`
+        : `${this.base}/v${version || this.version}${path}`;
+
       const optionsWithToken: RequestInit = {
         ...options,
         headers: this.withTokenHeader(options.headers),
@@ -355,7 +363,7 @@ class EncompassConnect {
     * ```
     */
   async request(url: string, options: RequestInit): Promise<Response> {
-    const response = await this.fetchWithRetry(url, options, { isNotJson: true });
+    const response = await this.fetchWithRetry(url, options, { isNotJson: true, useTruncatedBase: true });
     return response;
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -125,6 +125,7 @@ export interface InternalRequestOptions {
   isRetry?: boolean;
   isNotJson?: boolean;
   version?: number;
+  useTruncatedBase?: boolean;
 }
 
 export interface AssignMilestoneOptions {


### PR DESCRIPTION
Remove the `/encompass/v1/` slug from the `request()` call. This means this can be opened up to interact with other API endpoints not on the `encompass` path, such as `efolder` and `webhook` endpoints.